### PR TITLE
Collect cpu and mem info on minion side

### DIFF
--- a/big_tests/restart.sh
+++ b/big_tests/restart.sh
@@ -1,0 +1,3 @@
+docker-compose down
+docker-compose build
+docker-compose up

--- a/mdm/lib/machine.ex
+++ b/mdm/lib/machine.ex
@@ -10,10 +10,11 @@ defmodule MDM.Machine do
     ip: String.t,
     domain: String.t,
     ssh_host: String.t,
-    os: os()
+    os: os(),
+    resources: map()
   }
 
-  defstruct [:name, :id, :ip, :domain, :ssh_host, :os]
+  defstruct [:name, :id, :ip, :domain, :ssh_host, :os, :resources]
 
   ## JmmsrElement callbacks
 
@@ -31,5 +32,16 @@ defmodule MDM.Machine do
 
   def address(%__MODULE__{ip: ip, domain: nil}), do: ip
   def address(%__MODULE__{ip: nil, domain: domain}), do: domain
+
+  def add_resources(machine, resources), do: %{machine | resources: resources}
+
+  def find_machine_by_address(machines, address) do
+    case machines |> Enum.filter(fn machine -> of_address?(machine, address) end) do
+      [] -> :not_found
+      [machine] -> machine
+    end
+  end
+
+  defp of_address?(machine, addr), do: addr== address(machine)
 
 end

--- a/mdmminion/Dockerfile
+++ b/mdmminion/Dockerfile
@@ -4,6 +4,9 @@ RUN mkdir /app
 COPY ./ /app
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y \
+    util-linux
+
 RUN mix local.hex --force
 
 RUN mix do compile

--- a/mdmminion/lib/info_gatherer.ex
+++ b/mdmminion/lib/info_gatherer.ex
@@ -1,22 +1,37 @@
 defmodule MDMMinion.InfoGatherer do
   use GenServer
 
+  alias MDMMinion.LinuxGathererBackend
+
   require Logger
+
+  @callback machine_cpu_max :: integer()
 
   def start_link(), do: GenServer.start_link(__MODULE__, :ignored, name: __MODULE__)
 
-  def init(_), do: {:ok, :ignored}
+  def init(_) do
+    {:ok, %{gatherer_backend: get_backend()}}
+  end
 
-  def handle_call(:get_info, _from, :ignored) do
-    data = collect_data()
+  def handle_call(:get_info, _from, state) do
+    gatherer_backend = backend(state)
+    data = collect_data(gatherer_backend)
     {:reply, {:ok, data}, :ignored}
   end
 
-  def collect_data() do
-    Logger.info("Collecting info...")
+  def collect_data(backend) do
     %{
-      cpu: "test"
+      cpu: backend.machine_cpu_max
     }
   end
+
+  defp get_backend do
+    case :os.type do
+      {:unix, :linux} -> LinuxGathererBackend
+      _ -> :undefined
+    end
+  end
+
+  defp backend(%{gatherer_backend: backend}), do: backend
 
 end

--- a/mdmminion/lib/info_gatherer.ex
+++ b/mdmminion/lib/info_gatherer.ex
@@ -5,7 +5,12 @@ defmodule MDMMinion.InfoGatherer do
 
   require Logger
 
-  @callback machine_cpu_max :: integer()
+  @type unit :: :kb | :mhz
+  @type single_resource :: {float(), unit()}
+  @type gatherer_backend :: atom()
+
+  @callback machine_cpu_max :: single_resource()
+  @callback machine_mem_max :: single_resource()
 
   def start_link(), do: GenServer.start_link(__MODULE__, :ignored, name: __MODULE__)
 
@@ -19,9 +24,12 @@ defmodule MDMMinion.InfoGatherer do
     {:reply, {:ok, data}, :ignored}
   end
 
+  @spec collect_data(gatherer_backend()) :: %{cpu: single_resource(),
+                                              mem: single_resource()}
   def collect_data(backend) do
     %{
-      cpu: backend.machine_cpu_max
+      cpu: backend.machine_cpu_max,
+      mem: backend.machine_mem_max
     }
   end
 

--- a/mdmminion/lib/linux_gatherer_backend.ex
+++ b/mdmminion/lib/linux_gatherer_backend.ex
@@ -1,0 +1,17 @@
+defmodule MDMMinion.LinuxGathererBackend do
+  @behaviour MDMMinion.InfoGatherer
+
+  def machine_cpu_max do
+    cmd = :"(lscpu | grep -i 'CPU Max' || lscpu | grep -i 'CPU MHz') | awk '{print $NF}'"
+    res = :os.cmd(cmd)
+    {res_int, ""} = res
+                    |> to_string
+                    |> strip_newline
+                    |> Float.parse
+    res_int
+  end
+
+
+  defp strip_newline(str), do: String.trim(str, "\n")
+
+end

--- a/mdmminion/lib/linux_gatherer_backend.ex
+++ b/mdmminion/lib/linux_gatherer_backend.ex
@@ -8,7 +8,17 @@ defmodule MDMMinion.LinuxGathererBackend do
                     |> to_string
                     |> strip_newline
                     |> Float.parse
-    res_int
+    {res_int, :mhz}
+  end
+
+  def machine_mem_max do
+    cmd = :"awk -v \"awkmult=1\" '/MemTotal/{print $2*awkmult}' /proc/meminfo"
+    res = :os.cmd(cmd)
+    {res_int, ""} = res
+                    |> to_string
+                    |> strip_newline
+                    |> Float.parse
+    {res_int, :kb}
   end
 
 


### PR DESCRIPTION
For now we only collect from linuxes
TODO:
- [x] collect cpu max
- [x] collect mem max
- [x] add units

After this PR we will have to come up with a way to create a layer where we hold a JMMSR and only update it from "above" and ask about it from "underneath" - ws_communicator