### PR TITLE
Alias domains

### DIFF
--- a/big_tests/Dockerfile.minion
+++ b/big_tests/Dockerfile.minion
@@ -2,6 +2,7 @@ FROM elixir:latest
 
 RUN mkdir /app
 COPY ./mdmminion/ /app
+ADD ./big_tests/start_minion.sh /app
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y \
@@ -13,4 +14,6 @@ RUN mix do compile
 
 ARG DOMAIN
 ENV DOMAIN=${DOMAIN}
-CMD iex --sname minion@${DOMAIN} --cookie ala -S mix
+# Script checks if DOMAIN variable is empty
+# If so it uses IP
+CMD DOMAIN=${DOMAIN} ./start_minion.sh

--- a/big_tests/Dockerfile.pilot
+++ b/big_tests/Dockerfile.pilot
@@ -11,4 +11,4 @@ RUN mix do compile
 
 ARG DOMAIN
 ENV DOMAIN=${DOMAIN}
-CMD iex --sname pilot@${DOMAIN} --cookie ala -S mix
+CMD iex --name pilot@${DOMAIN} --cookie ala -S mix

--- a/big_tests/docker-compose.yml
+++ b/big_tests/docker-compose.yml
@@ -9,19 +9,25 @@ services:
       context: ..
       dockerfile: ./big_tests/Dockerfile.pilot
       args:
-        - DOMAIN=pilot
+        - DOMAIN=pilot.com
     ports:
       - "4000:8080"
 
   minion1:
+    networks:
+        default:
+            aliases:
+                - minion1.com
+    build:
+      dockerfile: ./big_tests/Dockerfile.minion
+      context: ..
+  minion2:
+    networks:
+        default:
+            aliases:
+                - minion2.com
     build:
       dockerfile: ./big_tests/Dockerfile.minion
       context: ..
       args:
-          - DOMAIN=minion1
-  minion2:
-      build:
-        dockerfile: ./big_tests/Dockerfile.minion
-        context: ..
-        args:
-            - DOMAIN=minion2
+          - DOMAIN=minion2.com

--- a/big_tests/example_ws_req_with_service
+++ b/big_tests/example_ws_req_with_service
@@ -1,0 +1,49 @@
+{"command_name": "collect_data", "body": {
+    "services": [
+        {"name": "some_server",
+         "service_dir": "/examples/some_server/",
+         "service_executable": "start.sh",
+         "containerized": false,
+         "requirements": {
+            "os": ["linux"], 
+            "ram": 25,
+            "hdd": 200,
+            "available_machines": [38]
+         }
+        },
+        {"name": "some_server2",
+         "service_dir": "/examples/some_server2/",
+         "service_executable": "start.sh",
+         "containerized": false,
+         "requirements": {
+            "os": ["linux"], 
+            "ram": 8324,
+            "hdd": 201,
+            "available_machines": [39]
+         }
+        }
+    ],
+"machines": [
+           {"id": 38,
+            "name": "ala",
+            "ip": "192.168.208.4",
+            "ssh_host": "LocalVM",
+            "os": "linux"
+           },
+            {"id": 39,
+            "name": "agi komp",
+            "domain": "minion2.com",
+            "ssh_host": "unknown",
+            "os": "linux"
+           }
+          ],
+"connections": [
+             ],
+"config": {"metrics": ["cpuUsage"],
+          "persist": true,
+          "persist_machine": 34,
+          "pilot_machine": 34
+        },
+"live_metrics": []
+}
+}

--- a/big_tests/examples/some_server/start.sh
+++ b/big_tests/examples/some_server/start.sh
@@ -1,2 +1,1 @@
-touch /kot.txt
-while true ; do sleep 5 && echo "ala" >> /kot.txt; done
+ping -c 2 some_server2 >> /ping.txt

--- a/big_tests/examples/some_server2/start.sh
+++ b/big_tests/examples/some_server2/start.sh
@@ -1,0 +1,1 @@
+ping -c 2 some_server >> /ping.txt

--- a/big_tests/start_minion.sh
+++ b/big_tests/start_minion.sh
@@ -1,7 +1,7 @@
 if [ -z "${DOMAIN}" ]
 then
     # if domain was not set, we use ip
-    LONG_NAME=$(hostname -i)
+    LONG_NAME=$(hostname -i) # Debian specific
     echo "Long name is $LONG_NAME"
     iex --name minion@${LONG_NAME} --cookie ala -S mix
 else

--- a/big_tests/start_minion.sh
+++ b/big_tests/start_minion.sh
@@ -1,0 +1,10 @@
+if [ -z "${DOMAIN}" ]
+then
+    # if domain was not set, we use ip
+    LONG_NAME=$(hostname -i)
+    echo "Long name is $LONG_NAME"
+    iex --name minion@${LONG_NAME} --cookie ala -S mix
+else
+    echo "Long name is $DOMAIN"
+    iex --name minion@${DOMAIN} --cookie ala -S mix
+fi

--- a/docs/Routing.md
+++ b/docs/Routing.md
@@ -1,0 +1,25 @@
+# Routing
+
+Routing between services is designed in a way so that networking between machines is transient for a user.
+One should use services names in places where they would use IP address or domain name.
+
+## Linux
+For mapping IPs to service names file `/etc/hosts` is used.
+For mapping Domain names to service names there is an environment variable
+`HOSTALIASES` used. It points to a file similar in the for to `/etc/hosts` but
+which can conatin domain names not only IPs. 
+
+The reason for not simply resolving domain names is to leave a user possibility to
+use round robin DNS as a way to load balance between services.
+
+### /etc/hosts and /host.aliases formats
+There is a difference between formats of mapping files this techinques
+accept.
+```
+/etc/hosts      IP_from         Domain_to
+/etc/hosts      Domain_to       Domain_from 
+```
+
+### NOTE
+It does not apply to serviecs that would play around with networking in some not standard way of course.
+This is because `HOSTALIASES` bypasses function gethostbyname() in glibc.

--- a/docs/Routing.md
+++ b/docs/Routing.md
@@ -1,12 +1,12 @@
 # Routing
 
 Routing between services is designed in a way so that networking between machines is transient for a user.
-One should use services names in places where they would use IP address or domain name.
+One should use services' names in places where they would use IP address or domain name.
 
 ## Linux
 For mapping IPs to service names file `/etc/hosts` is used.
-For mapping Domain names to service names there is an environment variable
-`HOSTALIASES` used. It points to a file similar in the for to `/etc/hosts` but
+For mapping domain names to service names there is an environment variable
+`HOSTALIASES` used. It points to a file similar in the form to `/etc/hosts` but
 which can conatin domain names not only IPs. 
 
 The reason for not simply resolving domain names is to leave a user possibility to

--- a/mdm/lib/deployment/deployer.ex
+++ b/mdm/lib/deployment/deployer.ex
@@ -53,6 +53,7 @@ defmodule MDM.Deployer do
   when fsm == :collected_data do
     with {:ok, decision} <- MDM.DeployDecider.decide(jmmsr),
          :ok <- MDM.ServiceUploader.upload_services(decision),
+         :ok <- MDM.ServiceUploader.prepare_routes(decision),
          :ok <- MDM.ServiceUploader.run_services()
     do
       resp = req |> answer("deployed", 200, %{})

--- a/mdm/lib/deployment/service_uploader.ex
+++ b/mdm/lib/deployment/service_uploader.ex
@@ -53,7 +53,7 @@ defmodule MDM.ServiceUploader do
   defp do_prepare_routes(decision) do
     routes =
     decision
-    |> Enum.map(fn {s, m} -> {Service.get_name(s), Machine.address(m)} end)
+    |> Enum.map(fn {s, m} -> {Machine.address(m), Service.get_name(s)} end)
     results = decision
           |> Enum.map(fn {_, machine} -> 
             node_name = Machine.node_name(machine)

--- a/mdmminion/lib/linux_router_backend.ex
+++ b/mdmminion/lib/linux_router_backend.ex
@@ -1,0 +1,32 @@
+defmodule MDMMinion.LinuxRouterBackend do
+  @behaviour MDMMinion.Router
+  require Logger
+
+  def register_routes(routes) do
+    res0 =
+    routes
+    |> Enum.map(fn {f, t} -> "echo \"#{f} #{t}\" >> /etc/host.aliases" |> String.to_atom end)
+    |> Enum.map(fn cmd -> 
+      Logger.info("Executing #{cmd}")
+      :os.cmd(cmd) end)
+
+    res = [save_aliases() | res0]
+    ok? = res |> Enum.all?(fn r -> r == [] end)
+    case ok? do
+      true -> :ok
+      _ ->
+        {:error, res |> Enum.find(fn r -> r != [] end)}
+    end
+  end
+
+  defp save_aliases do
+    # this line is not that important
+    :os.cmd("echo \"export HOSTALIASES=/etc/host.aliases\" >> /etc/profile && . /etc/profile" |> String.to_atom) 
+    case System.put_env("HOSTALIASES", "/etc/host.aliases") do
+      :ok -> []
+      error -> {:error, error}
+    end
+  end
+
+
+end

--- a/mdmminion/lib/minion_app.ex
+++ b/mdmminion/lib/minion_app.ex
@@ -3,6 +3,7 @@ defmodule MDMMinion.MDMMinionApp do
 
   alias MDMMinion.InfoGatherer
   alias MDMMinion.Deployer
+  alias MDMMinion.Router
 
   def start(_type, _args) do
     Supervisor.start_link(children(), strategy: :one_for_one)
@@ -18,6 +19,10 @@ defmodule MDMMinion.MDMMinionApp do
       %{
         id: Deployer,
         start: {Deployer, :start_link, []}
+      },
+      %{
+        id: Router,
+        start: {Router, :start_link, []}
       }
     ]
   end

--- a/mdmminion/lib/router.ex
+++ b/mdmminion/lib/router.ex
@@ -2,7 +2,8 @@ defmodule MDMMinion.Router do
   use GenServer
   # TODO clean up
   
-  @callback register_routes({domain :: String.t, address :: String.t})
+  # mapping of addresses from `from` to `to`
+  @callback register_routes({from :: String.t, to :: String.t})
   :: :ok | {:error, reason :: any()}
 
   def start_link,
@@ -11,7 +12,7 @@ defmodule MDMMinion.Router do
   ## GenSErver callbacks
 
   def init(_) do
-    b = get_backend
+    b = get_backend()
     {:ok, %{backend: b}}
   end
 

--- a/mdmminion/lib/router.ex
+++ b/mdmminion/lib/router.ex
@@ -1,0 +1,29 @@
+defmodule MDMMinion.Router do
+  use GenServer
+  # TODO clean up
+  
+  @callback register_routes({domain :: String.t, address :: String.t})
+  :: :ok | {:error, reason :: any()}
+
+  def start_link,
+  do: GenServer.start_link(__MODULE__, :ignore, name: __MODULE__)
+
+  ## GenSErver callbacks
+
+  def init(_) do
+    b = get_backend
+    {:ok, %{backend: b}}
+  end
+
+  def handle_call({:register_routes, routes}, _, %{backend: b} = s),
+    do: {:reply, b.register_routes(routes), s}
+
+  ## Private
+  defp get_backend do
+    case :os.type do
+      {:unix, :linux} -> MDMMinion.LinuxRouterBackend
+      _ -> :undefined
+    end
+  end
+
+end


### PR DESCRIPTION
TODO:
- [x] make sure it works on ips as well (host aliases may not be suited for aliasing IPs. We have to then also use /etc/hosts) - it does not work with IPs
- [x] Differentiate ips from domain names and write them either in /etc/hosts or /etc/host.aliases