### PR TITLE
Network per service metrics

### DIFF
--- a/big_tests/Dockerfile.minion
+++ b/big_tests/Dockerfile.minion
@@ -8,7 +8,8 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y \
     util-linux \
     python3 \
-    ifstat
+    ifstat \
+    nethogs
 
 RUN mix local.hex --force
 

--- a/big_tests/examples/forker_pinger_system/server3/start.sh
+++ b/big_tests/examples/forker_pinger_system/server3/start.sh
@@ -1,4 +1,3 @@
 ping -c 5 server1
 
-gcc forker.c -o forker
-./forker
+wget http://ipv4.download.thinkbroadband.com/1GB.zip

--- a/mdmminion/lib/linux_deployer_backend.ex
+++ b/mdmminion/lib/linux_deployer_backend.ex
@@ -23,7 +23,6 @@ defmodule MDMMinion.LinuxDeployerBackend do
   end
 
   def get_cpu_usage(session_id) do
-    Logger.info "collecting cpu usage..."
     res = get_processes(session_id)
     |> Enum.map(&get_cpu_of_pid/1)
     |> Enum.filter(fn e -> e != {:error, :cant_parse} end) # it should mean the process died, we warn in logs about this situation
@@ -33,7 +32,6 @@ defmodule MDMMinion.LinuxDeployerBackend do
   end
 
   def get_mem_usage(session_id) do
-    Logger.info "collecting mem usage..."
     res = get_processes(session_id)
     |> Enum.map(&get_mem_of_pid/1)
     |> Enum.filter(fn e -> e != {:error, :cant_parse} end) # it should mean the process died, we warn in logs about this situation
@@ -42,9 +40,70 @@ defmodule MDMMinion.LinuxDeployerBackend do
     res
   end
 
+  def get_net_usage(session_id) do
+    case nethogs_installed?() do
+      true ->
+        stats = get_per_pid_net_stats()
+        res = get_processes(session_id)
+              |> Enum.map(fn pid -> get_net_of_pid(stats, pid) end)
+              |> Enum.reduce({0, 0},
+                             fn({inn, out}, {in_acc, out_acc}) -> {inn + in_acc, out + out_acc} end)
+                               Logger.info "Net usage for session #{session_id |> to_string} is #{inspect(res)}"
+                               res
+      false ->
+        {:error, :nethogs_not_installed}
+    end
+  end
 
-  ## Private
   
+  ## Private
+
+  defp get_net_of_pid(stats, pid) do
+    case List.keyfind(stats, pid, 0) do
+      nil -> {0.0, 0.0} # If it's not here it means it does not use network
+      {^pid, net_in, net_out} -> {net_in, net_out}
+    end
+  end
+
+  defp get_per_pid_net_stats do
+    # TODO this is a little bit volatile so we probably need to fix
+    # the version of nethogs (in case it's api changes or sth)
+    cmd = "nethogs -bc 2 2> /dev/null | awk '{$1=$1};1'"
+    :os.cmd(cmd |> String.to_atom)
+    |> to_string
+    |> String.split("\nRefreshing:\n")
+    |> Enum.at(2)
+    |> String.split("\n")
+    |> Enum.filter(fn e -> e != "" end) # Splitting on newline leaves one empty string
+    |> Enum.map(&parse_nethogs_line/1)
+    |> Enum.filter(fn e -> e != :unknown end)
+  end
+
+  @spec parse_nethogs_line(String.t) :: {pid :: integer(), net_in :: float(), net_out :: float()} | :unknown
+  defp parse_nethogs_line("unknown" <> _), do: :unknown # there is a collective net stat for unknonwn pids, we omit it
+  defp parse_nethogs_line(line) do
+    [process, out, inn] = line
+                          |> String.split(" ")
+    pid = process
+          |> String.split("/")
+          |> Enum.reverse
+          |> Enum.at(1)
+          |> Integer.parse
+          |> elem(0)
+    {out_f, _} = Float.parse(out)
+    {in_f, _} = Float.parse(inn)
+    {pid, in_f, out_f}
+  end
+
+  defp nethogs_installed? do
+    case System.find_executable("nethogs") do
+      nil ->
+        Logger.warn "nethogs is not installed. Network statistics for services won't be available"
+        false
+      _ -> true
+    end
+  end
+
   defp get_cpu_of_pid(pid) do
     cores_no = get_cores_no()
     get_resource_of_pid(pid, "cpu") / cores_no
@@ -66,6 +125,10 @@ defmodule MDMMinion.LinuxDeployerBackend do
 
   defp get_resource_of_pid(pid, resource) do
     cmd = "ps -p #{pid |> to_string} -o %#{resource} | tail -n 1 | awk '{$1=$1};1'"
+    execute_to_float(cmd)
+  end
+
+  defp execute_to_float(cmd, warn? \\ true) do
     res = :os.cmd(cmd |> String.to_atom)
     |> to_string
     |> Float.parse
@@ -73,11 +136,13 @@ defmodule MDMMinion.LinuxDeployerBackend do
       {val, "\n"} ->
         val
       _ ->
+        warn? and
         Logger.warn(
           "Couldn't parse #{inspect(res)}. It probably means pid died meanwhile"
         )
         {:error, :cant_parse}
     end
+
   end
 
   defp generate_service_dir_name(s), do: s

--- a/mdmminion/lib/service.ex
+++ b/mdmminion/lib/service.ex
@@ -41,7 +41,8 @@ defmodule MDMMinion.Service do
   def handle_call(:get_metrics, _, state) do
     cpu_usage = state.backend.get_cpu_usage(state.id)
     mem_usage = state.backend.get_mem_usage(state.id)
-    metric = %{cpu: cpu_usage, mem: mem_usage, net: {54, 23}}
+    net_usage = state.backend.get_net_usage(state.id)
+    metric = %{cpu: cpu_usage, mem: mem_usage, net: net_usage}
     {:reply, {:ok, metric}, state}
   end
 


### PR DESCRIPTION
This PR introduces the requirement of having `nethogs` installed on minion machines. If it is not installed, metrics of network per service won't be collected